### PR TITLE
Adding block number and byte size to status bar

### DIFF
--- a/src/clusters.cc
+++ b/src/clusters.cc
@@ -156,6 +156,8 @@ Clusters::collect_fragments(const Glib::ustring &initial_dir)
     device_size_ = sfs.f_blocks;
     cluster_count_ = (device_size_ - 1) / cluster_size_ + 1;
 
+    device_block_size_ = sb_root.st_blksize;
+
     clear_caches();
     files_.clear();
 

--- a/src/clusters.hh
+++ b/src/clusters.hh
@@ -91,6 +91,9 @@ public:
     uint64_t
     get_device_size() const { return this->device_size_; }
 
+    uint64_t
+    get_device_block_size() const { return this->device_block_size_; }
+
     void
     __fill_clusters(uint64_t m_start, uint64_t m_length);
 
@@ -143,6 +146,7 @@ private:
     pthread_mutex_t clusters_mutex_;
     pthread_mutex_t files_mutex_;
     uint64_t        device_size_;
+    uint64_t        device_block_size_;
     uint64_t        cluster_count_;
     uint64_t        cluster_size_;
     bool            hide_error_inaccessible_files_;

--- a/src/fragmap-widget.hh
+++ b/src/fragmap-widget.hh
@@ -69,6 +69,12 @@ public:
     
     bool
     highlight_cluster_at(double x, double y);
+
+    void
+    update_statusbar();
+
+    const std::string
+    human_size(uint64_t bytes);
     
     void
     recalculate_sizes(int pix_width, int pix_height);


### PR DESCRIPTION
I came across this app via your StackOverflow answer, and it was exactly what I was looking for!  So, thanks very much for making this.  I wanted to have an easier way of getting an idea of where exactly I was on the hard drive without doing a bunch of math (that's what computers are for!), so I added a couple things to the status bar: block number (just within the blocks currently being analyzed, nothing fancy) and the block size in bytes.

C++ isn't my main language, and I haven't worked as much with stdlib, so I apologize for any awkwardness in the code, but I tried to keep it clean.  Let me know if you have any questions :)