### PR TITLE
mountpoint-select-dialog: don't show the last entry twice

### DIFF
--- a/src/mountpoint-select-dialog.cc
+++ b/src/mountpoint-select-dialog.cc
@@ -97,10 +97,14 @@ MountpointSelectDialog::MountpointSelectDialog()
     m_f.open("/proc/mounts");
     std::locale clocale("C");
     m_f.imbue(clocale);
-    std::string m_device, m_mountpoint, m_type, m_options, m_freq, m_passno;
 
     while (!m_f.eof()) {
+        std::string m_device, m_mountpoint, m_type, m_options, m_freq, m_passno;
         m_f >> m_device >> m_mountpoint >> m_type >> m_options >> m_freq >> m_passno;
+
+        if (m_mountpoint.empty())
+            continue;
+
         struct statfs64 sfsb;
         struct stat64 sb;
         if (0 != statfs64(m_mountpoint.c_str(), &sfsb))


### PR DESCRIPTION
Currently, the mountpoint selection dialog shows the last entry in the list twice.

This is caused by incorrect EOF handling:
EOF is hit while trying to do formatted input after the last complete line is read.
Formatted input doesn't get anything from the stream,
but there are no checks for that,
so the loop continues with values from the previous iteration.

Check if `m_mountpoint` is empty before proceeding with statfs() and friends.